### PR TITLE
Refactor styles, add variable to adjust heading color

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For compatibility with previous model version use `3.x.x` version of the compone
 
 Custom property | Description | Default
 ----------------|-------------|----------
-`--api-body-document-title-border-color` | Border color of the section title | `#e5e5e5`
+`--api-parameters-document-title-border-color` | Border color of the section title | `#e5e5e5`
 `--api-body-document-toggle-view-color` | Color of the toggle view button | `--arc-toggle-view-icon-color` or `rgba(0, 0, 0, 0.74)`
 `--api-body-document-toggle-view-hover-color` | Color of the toggle view button when hovered | `var(--arc-toggle-view-icon-hover-color` or `rgba(0, 0, 0, 0.88)`
 `--api-body-document-description-color` | Color of the type description | `rgba(0, 0, 0, 0.74)`
@@ -28,19 +28,23 @@ Custom property | Description | Default
 `--api-body-document-examples-border-color` | Example section border color | `transparent`
 `--code-background-color` | Background color of the examples section | ``
 `--api-body-document-media-type-label-font-weight` | Font weight of the media type label (when selection is not available) | `500`
-`--api-body-document-title-narrow-font-size`  |   |  `initial`,
+`--arc-font-subhead-font-size` | Font size of the collapsible section title | ``
+`--arc-font-subhead-font-color` | Font color of the collapsible section title | ``
+`--arc-font-subhead-font-font-weight` | Font weight of the collapsible section title | ``
+`--arc-font-subhead-font-line-height` | Line height of the collapsible section title | ``
+`--arc-font-subhead-narrow-font-size`  | Font size of the collapsible section title in mobile-friendly view |  `17px`,
+`--arc-font-body2-font-size` | Font size of the type title | ``
+`--arc-font-body2-font-weight` | Font weight of the type title | ``
+`--arc-font-body2-line-height` | Line height of the type title | ``
 `--api-body-document-code-color`  |   |  `initial`
 `--api-body-document-any-info-font-size`  |   |  `16px`
 `--api-body-document-any-info-font-weight`  |   |  `500`
 
-### API components
-
-This components is a part of [API components ecosystem](https://elements.advancedrestclient.com/)
-
 ## Usage
 
 ### Installation
-```
+
+```sh
 npm install --save @api-components/api-body-document
 ```
 
@@ -90,6 +94,11 @@ npm start
 ```
 
 ### Running the tests
+
 ```sh
 npm test
 ```
+
+## API components
+
+This component is a part of [API components ecosystem](https://elements.advancedrestclient.com/)

--- a/src/ApiBodyDocumentElement.js
+++ b/src/ApiBodyDocumentElement.js
@@ -580,7 +580,7 @@ export class ApiBodyDocumentElement extends AmfHelperMixin(LitElement) {
       title="Toogle body details"
       ?opened="${opened}"
     >
-      <div class="table-title" role="heading" aria-level="${headerLevel}">Body</div>
+      <div class="heading3" role="heading" aria-level="${headerLevel}">Body</div>
       <div class="title-area-actions">
         <anypoint-button
           class="toggle-button"

--- a/src/Styles.js
+++ b/src/Styles.js
@@ -42,6 +42,7 @@ export default css`
 
 .heading3 {
   flex: 1;
+  color: var(--arc-font-subhead-color);
   font-size: var(--arc-font-subhead-font-size);
   font-weight: var(--arc-font-subhead-font-weight);
   line-height: var(--arc-font-subhead-line-height);

--- a/src/Styles.js
+++ b/src/Styles.js
@@ -16,23 +16,14 @@ export default css`
   display: flex;
   flex-direction: row;
   align-items: center;
+  border-bottom: 1px var(--api-parameters-document-title-border-color, var(--api-parameters-document-title-border-color, #e5e5e5)) solid;
   cursor: pointer;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
-  border-bottom: 1px var(--api-body-document-title-border-color, #e5e5e5) solid;
   transition: border-bottom-color 0.15s ease-in-out;
 }
 
 .section-title-area[opened] {
   border-bottom-color: transparent;
-}
-
-.section-title-area .table-title {
-  flex: 1;
-  flex-basis: 0.000000001px;
-  font-size: var(--api-body-document-title-narrow-font-size, initial);
 }
 
 .toggle-button {
@@ -49,14 +40,15 @@ export default css`
   transform: rotateZ(-180deg);
 }
 
-.table-title {
+.heading3 {
+  flex: 1;
   font-size: var(--arc-font-subhead-font-size);
   font-weight: var(--arc-font-subhead-font-weight);
   line-height: var(--arc-font-subhead-line-height);
 }
 
-:host([narrow]) .table-title {
-  font-size: var(--api-body-document-title-narrow-font-size, initial);
+:host([narrow]) .heading3 {
+  font-size: var(--api-body-document-title-narrow-font-size, var(--arc-font-subhead-narrow-font-size, 17px));
 }
 
 .type-title {

--- a/test/api-body-document.test.js
+++ b/test/api-body-document.test.js
@@ -263,7 +263,7 @@ describe('ApiBodyDocumentElement', () => {
         });
 
         it('Narrow style is applied to the URI title', () => {
-          element.style.setProperty('--api-body-document-title-narrow-font-size', '16px');
+          element.style.setProperty('--arc-font-subhead-narrow-font-size', '16px');
           const title = element.shadowRoot.querySelector('.table-title');
           const fontSize = getComputedStyle(title).fontSize;
           assert.equal(fontSize, '16px');

--- a/test/api-body-document.test.js
+++ b/test/api-body-document.test.js
@@ -264,7 +264,7 @@ describe('ApiBodyDocumentElement', () => {
 
         it('Narrow style is applied to the URI title', () => {
           element.style.setProperty('--arc-font-subhead-narrow-font-size', '16px');
-          const title = element.shadowRoot.querySelector('.table-title');
+          const title = element.shadowRoot.querySelector('.heading3');
           const fontSize = getComputedStyle(title).fontSize;
           assert.equal(fontSize, '16px');
         });


### PR DESCRIPTION
1. Use `--api-parameters-document-title-border-color` for all collapsible sections to unify the appearance with single variable (see also https://github.com/advanced-rest-client/api-method-documentation/pull/36).
2. Replace the `.table-title` class with `.heading3` like it's done in other sections.
3. Change `--api-body-document-title-narrow-font-size` to `--arc-font-subhead-narrow-font-size` (same as in other sections).
4. Add `--arc-font-subhead-color` to allow heading color modification.