### PR TITLE
Customize body document style heading

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-body-document",
   "description": "A component to render HTTP method body documentation based on AMF model",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/Styles.js
+++ b/src/Styles.js
@@ -17,6 +17,7 @@ export default css`
   flex-direction: row;
   align-items: center;
   border-bottom: 1px var(--api-body-document-title-border-color, var(--api-parameters-document-title-border-color, #e5e5e5)) solid;
+  border: var(--api-body-document-title-border);
   cursor: pointer;
   user-select: none;
   transition: border-bottom-color 0.15s ease-in-out;
@@ -42,10 +43,11 @@ export default css`
 
 .heading3 {
   flex: 1;
-  color: var(--arc-font-subhead-color);
-  font-size: var(--arc-font-subhead-font-size);
-  font-weight: var(--arc-font-subhead-font-weight);
-  line-height: var(--arc-font-subhead-line-height);
+  font-family: var(--api-body-document-h3-font-family, var(--arc-font-subhead-font-family));
+  color: var(--api-body-document-h3-font-color, var(--arc-font-subhead-color));
+  font-size: var(--api-body-document-h3-font-size, var(--arc-font-subhead-font-size));
+  font-weight: var(--api-body-document-h3-font-weight, var(--arc-font-subhead-font-weight));
+  line-height: var(--api-body-document-h3-line-height, var(--arc-font-subhead-line-height));
 }
 
 :host([narrow]) .heading3 {


### PR DESCRIPTION
Fixes [#27](https://github.com/advanced-rest-client/api-documentation/issues/27)

- customize border and heading font