### PR TITLE
Fix border bottom CSS var style

### DIFF
--- a/src/Styles.js
+++ b/src/Styles.js
@@ -16,8 +16,9 @@ export default css`
   display: flex;
   flex-direction: row;
   align-items: center;
-  border-bottom: 1px var(--api-body-document-title-border-color, var(--api-parameters-document-title-border-color, #e5e5e5)) solid;
-  border: var(--api-body-document-title-border);
+  border-bottom: var(--api-body-document-title-border-bottom,
+    1px var(--api-body-document-title-border-color, var(--api-parameters-document-title-border-color, #e5e5e5)) solid
+  );
   cursor: pointer;
   user-select: none;
   transition: border-bottom-color 0.15s ease-in-out;


### PR DESCRIPTION
Fixes `border` property overriding the style of `border-bottom` when the CSS variable is undefined

Fixes issue introduced by this commit https://github.com/advanced-rest-client/api-body-document/commit/ded3611524d488d7fc23ab2c12d12a76295a7230#diff-eccc2b8fef024888c50f0586687e68415115c3cc38bd9fda26ba1d4cbd0ce0dcR20
