### PR TITLE
Fix/description missing

### DIFF
--- a/demo/APIC-758/APIC-758.yaml
+++ b/demo/APIC-758/APIC-758.yaml
@@ -1,0 +1,53 @@
+openapi: "3.0.0"
+externalDocs:
+  url: petstore.com
+  description: Pet Store website
+info:
+  version: 1.0.0
+  title: OpenAPI Spec 3.0  Petstore
+
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+paths:
+  /pets:
+    post:
+      summary: Create a pet
+      requestBody:
+        description: Pet to add
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+      responses:
+        "201":
+          description: Null response
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"

--- a/demo/apis.json
+++ b/demo/apis.json
@@ -9,5 +9,6 @@
   "APIC-463/APIC-463.raml": "RAML 1.0",
   "SE-12291/SE-12291.json": "OAS 2.0",
   "anyOf/anyOf.yaml": "ASYNC 2.0",
-  "steveTest-1/stevetest.json": "OAS 2.0"
+  "steveTest-1/stevetest.json": "OAS 2.0",
+  "APIC-758/APIC-758.yaml": "OAS 3.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-body-document",
-  "version": "4.4.4",
+  "version": "4.4.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-body-document",
   "description": "A component to render HTTP method body documentation based on AMF model",
-  "version": "4.4.4",
+  "version": "4.4.5",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ApiBodyDocumentElement.d.ts
+++ b/src/ApiBodyDocumentElement.d.ts
@@ -30,6 +30,14 @@ export declare class ApiBodyDocumentElement extends AmfHelperMixin(LitElement) {
    */
   body: any[];
   /**
+   * requestBody description for OAS 3.0 specs
+   */
+  bodyDescription: string;
+  /**
+   * requestBody description for OAS 3.0 specs
+   */
+  _bodyDescription: string;
+  /**
    * List of discovered media types in the `body`.
    */
   _mediaTypes: any[];

--- a/src/ApiBodyDocumentElement.js
+++ b/src/ApiBodyDocumentElement.js
@@ -42,6 +42,10 @@ export class ApiBodyDocumentElement extends AmfHelperMixin(LitElement) {
        */
       body: { type: Array },
       /**
+       * requestBody description for OAS 3.0 specs
+       */
+      bodyDescription: { type: String },
+      /**
        * List of discovered media types in the `body`.
        */
       _mediaTypes: { type: Array },
@@ -201,6 +205,19 @@ export class ApiBodyDocumentElement extends AmfHelperMixin(LitElement) {
     this._selectedBody = this._computeSelectedBody(this.selected, value);
     this._selectedMediaType = this._computeSelectedMediaName(this.selected, value);
     this._bodyChanged();
+  }
+
+  get bodyDescription() {
+    return this._bodyDescription;
+  }
+
+  set bodyDescription(value) {
+    const old = this._bodyDescription;
+    if (old === value) {
+      return;
+    }
+    this._bodyDescription = value;
+    this.requestUpdate('bodyDescription', old);
   }
 
   get toggleActionLabel() {
@@ -478,10 +495,12 @@ export class ApiBodyDocumentElement extends AmfHelperMixin(LitElement) {
       amf,
       narrow,
       renderReadOnly,
+      bodyDescription
     } = this;
     const hasBodyName = !!_bodyName;
     const hasDescription = !!_description;
     const hasTypeName = _typeName && _typeName !== 'default';
+    const hasBodyDescription = !!bodyDescription
 
     return html`
     <div class="media-type-selector">
@@ -490,6 +509,10 @@ export class ApiBodyDocumentElement extends AmfHelperMixin(LitElement) {
         this._mediaTypesTemplate() :
         html`<span class="media-type-label">${_selectedMediaType}</span>`}
     </div>
+    ${hasBodyDescription ? html`
+        <arc-marked .markdown="${bodyDescription}" sanitize>
+            <div slot="markdown-html" class="markdown-html" part="markdown-html"></div>
+        </arc-marked>` : ''}
     ${hasBodyName ? html`<div class="body-name type-title">${_bodyName}</div>` : ''}
     ${hasTypeName ? html`<div class="type-title">${_typeName}</div>` : ''}
     ${hasDescription ? html`

--- a/test/api-body-document.test.js
+++ b/test/api-body-document.test.js
@@ -560,4 +560,35 @@ describe('ApiBodyDocumentElement', () => {
       });
     });
   });
+
+  describe('OAS 3.0', () => {
+    [
+      ['Full AMF model', false],
+      ['Compact AMF model', true]
+    ].forEach(([label, compact]) => {
+      describe(String(label), () => {
+        let element = /** @type ApiBodyDocumentElement */ (null);
+        let amf;
+        let payload;
+
+        before(async () => {
+          amf = await AmfLoader.load(compact, 'APIC-758');
+          payload = AmfLoader.lookupReturnsPayload(amf, '/pets', 'post', 201);
+        });
+
+        beforeEach(async () => {
+          element = await openedFixture();
+          element.amf = amf;
+          element.body = payload;
+          element.bodyDescription = 'Pet to add';
+          await nextFrame();
+          await aTimeout(0);
+        });
+
+        it('Sets body description value', async () => {
+          assert.equal(element._bodyDescription, 'Pet to add');
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
In OAS 3.0 a description can be defined for requestBody node. We were not showing it in the body documentation section.